### PR TITLE
fix: update all references from criterion to criterionx

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@criterionx/core"><img src="https://img.shields.io/npm/v/@criterionx/core.svg" alt="npm version"></a>
-  <a href="https://github.com/tomymaritano/criterion/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/@criterionx/core.svg" alt="license"></a>
+  <a href="https://github.com/tomymaritano/criterionx/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/@criterionx/core.svg" alt="license"></a>
   <a href="https://tomymaritano.github.io/criterionx/"><img src="https://img.shields.io/badge/docs-vitepress-brightgreen.svg" alt="docs"></a>
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -110,4 +110,4 @@ The core will remain small, pure, and focused.
 
 Want to help shape Criterion's future? See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-Ideas and feedback are welcome in [GitHub Discussions](https://github.com/tomymaritano/criterion/discussions).
+Ideas and feedback are welcome in [GitHub Discussions](https://github.com/tomymaritano/criterionx/discussions).

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -4,10 +4,10 @@ export default defineConfig({
   title: "Criterion",
   description: "Universal decision engine for business-critical decisions",
 
-  base: "/criterion/",
+  base: "/criterionx/",
 
   head: [
-    ["link", { rel: "icon", type: "image/svg+xml", href: "/criterion/logo.svg" }],
+    ["link", { rel: "icon", type: "image/svg+xml", href: "/criterionx/logo.svg" }],
   ],
 
   themeConfig: {
@@ -77,7 +77,7 @@ export default defineConfig({
     },
 
     socialLinks: [
-      { icon: "github", link: "https://github.com/tomymaritano/criterion" },
+      { icon: "github", link: "https://github.com/tomymaritano/criterionx" },
     ],
 
     footer: {
@@ -90,7 +90,7 @@ export default defineConfig({
     },
 
     editLink: {
-      pattern: "https://github.com/tomymaritano/criterion/edit/main/docs/:path",
+      pattern: "https://github.com/tomymaritano/criterionx/edit/main/docs/:path",
       text: "Edit this page on GitHub",
     },
   },

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ hero:
       link: /guide/getting-started
     - theme: alt
       text: View on GitHub
-      link: https://github.com/tomymaritano/criterion
+      link: https://github.com/tomymaritano/criterionx
 
 features:
   - icon: 🎯

--- a/package.json
+++ b/package.json
@@ -45,12 +45,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tomymaritano/criterion.git"
+    "url": "https://github.com/tomymaritano/criterionx.git"
   },
   "bugs": {
-    "url": "https://github.com/tomymaritano/criterion/issues"
+    "url": "https://github.com/tomymaritano/criterionx/issues"
   },
-  "homepage": "https://github.com/tomymaritano/criterion#readme",
+  "homepage": "https://github.com/tomymaritano/criterionx#readme",
   "devDependencies": {
     "@vitest/coverage-v8": "^2.0.0",
     "tsup": "^8.0.0",


### PR DESCRIPTION
## Summary

Fixes all internal references after repository rename from `criterion` to `criterionx`.

**Changes:**
- VitePress `base` path: `/criterion/` → `/criterionx/`
- VitePress logo href: `/criterion/logo.svg` → `/criterionx/logo.svg`
- All GitHub URLs updated to `criterionx` repo
- Git remote URL updated

## Problem

The VitePress documentation site was not loading because:
- GitHub Pages serves from `/criterionx/`
- VitePress was configured with `base: "/criterion/"`
- All CSS, JS, and image assets returned 404

## Test plan

- [x] `npm run docs:build` passes
- [ ] Verify documentation loads at https://tomymaritano.github.io/criterionx/