### PR TITLE
chore: add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug Report
+about: Report a bug in Criterion
+title: "[Bug]: "
+labels: bug
+assignees: ''
+---
+
+## Describe the Bug
+
+<!-- A clear description of what the bug is -->
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What you expected to happen -->
+
+## Actual Behavior
+
+<!-- What actually happened -->
+
+## Code Example
+
+```typescript
+// Minimal code to reproduce the issue
+```
+
+## Environment
+
+- Criterion version:
+- Node.js version:
+- TypeScript version:
+- OS:
+
+## Additional Context
+
+<!-- Any other context about the problem -->
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,38 @@
+---
+name: Feature Request
+about: Suggest an idea for Criterion
+title: "[Feature]: "
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+
+<!-- What problem does this feature solve? -->
+
+## Proposed Solution
+
+<!-- How would you like this to work? -->
+
+## Alternatives Considered
+
+<!-- Any alternative solutions you've considered -->
+
+## Use Case
+
+```typescript
+// Example of how this feature would be used
+```
+
+## Additional Context
+
+<!-- Any other context, screenshots, or references -->
+
+## Checklist
+
+Before submitting, please confirm:
+
+- [ ] I have searched existing issues to avoid duplicates
+- [ ] This feature aligns with Criterion's philosophy (pure, deterministic, explainable)
+- [ ] This is NOT in the [Out of Scope](/docs/architecture/out-of-scope.md) list
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+## Summary
+
+<!-- Describe what this PR does in 1-3 sentences -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+
+## Changes
+
+<!-- List the main changes -->
+
+-
+
+## Test Plan
+
+<!-- How did you test these changes? -->
+
+- [ ] Unit tests pass (`npm test`)
+- [ ] Type check passes (`npm run typecheck`)
+- [ ] Build succeeds (`npm run build`)
+- [ ] Docs build succeeds (`npm run docs:build`) — if applicable
+
+## Checklist
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my code
+- [ ] I have added tests that prove my fix/feature works
+- [ ] New and existing tests pass locally
+- [ ] I have updated documentation if needed
+
+## Related Issues
+
+<!-- Link any related issues: Closes #123, Fixes #456 -->
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,49 @@ Optional but recommended:
 
 ---
 
+## Commit Message Convention
+
+Criterion uses [Conventional Commits](https://www.conventionalcommits.org/).
+
+### Format
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer]
+```
+
+### Types
+
+| Type | When to Use |
+|------|-------------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `test` | Adding or updating tests |
+| `chore` | Maintenance tasks (deps, CI, etc.) |
+| `perf` | Performance improvement |
+
+### Examples
+
+```
+feat(engine): add support for async rule evaluation
+fix(validation): handle null values in input schema
+docs(examples): add healthcare triage example
+refactor(core): simplify rule matching logic
+test(engine): add coverage for NO_MATCH status
+chore(deps): update vitepress to v1.6.4
+```
+
+### Scope (optional)
+
+Common scopes: `engine`, `validation`, `profiles`, `types`, `examples`, `docs`, `ci`
+
+---
+
 ## Pull Request Policy
 
 Every Pull Request must:


### PR DESCRIPTION
## Summary

Adds GitHub templates for better contribution workflow.

## Changes

- **PR Template** (`.github/PULL_REQUEST_TEMPLATE.md`)
  - Summary section
  - Type of change checklist
  - Test plan checklist
  - Related issues section

- **Issue Templates**
  - Bug report with reproduction steps
  - Feature request with philosophy checklist

- **CONTRIBUTING.md**
  - Added commit message convention (Conventional Commits)
  - Types: feat, fix, docs, refactor, test, chore, perf
  - Examples and common scopes

## Test plan

- [ ] Create new PR and verify template appears
- [ ] Create new issue and verify templates appear